### PR TITLE
Improved Library Search

### DIFF
--- a/MieLibrary/ContentView.swift
+++ b/MieLibrary/ContentView.swift
@@ -16,14 +16,6 @@ struct ContentView: View {
         animation: .default
     ) private var books: [Book]
     
-    private var filteredBooks: [Book] {
-        if searchText.isEmpty {
-            return books
-        } else {
-            return books.filter({ $0.search(with: searchText) })
-        }
-    }
-    
     init() {
         let tabAppearance = UITabBarAppearance()
         tabAppearance.configureWithTransparentBackground()

--- a/MieLibrary/Models/Book.swift
+++ b/MieLibrary/Models/Book.swift
@@ -97,10 +97,47 @@ final class Book: Identifiable {
             return true
         }
         
-        if !tags.filter({ $0.contains(text.lowercased()) }).isEmpty {
-            return true
-        }
-        
         return false
+    }
+}
+
+extension Array where Element == Book {
+    func search(for text: String) -> [Book] {
+        let splitText = text.split(separator: "=")
+        
+        if splitText.count > 1 {
+            let searchText = splitText[0].lowercased()
+            let searchPhrase = splitText[1].lowercased()
+            
+            if searchText == "tag" || searchText == "tags" {
+                return self.filter({ !$0.tags.filter({ $0.contains(searchPhrase) }).isEmpty })
+            }
+            
+            if searchText == "author" {
+                return self.filter({ $0.author.lowercased().contains(searchPhrase) })
+            }
+            
+            if searchText == "publisher" {
+                return self.filter({
+                    guard let publisher = $0.publisher else { return false }
+                    return publisher.lowercased().contains(searchPhrase)
+                })
+            }
+            
+            if searchText == "series" {
+                return self.filter({
+                    guard let series = $0.series else { return false }
+                    return series.lowercased().contains(searchPhrase)
+                })
+            }
+            
+            if searchText == "genre" {
+                return self.filter({ $0.genre.rawValue.contains(searchPhrase) })
+            }
+            
+            return []
+        } else {
+            return self.filter({ $0.search(with: text) })
+        }
     }
 }

--- a/MieLibrary/Views/BookDetails/BookDetailsPage.swift
+++ b/MieLibrary/Views/BookDetails/BookDetailsPage.swift
@@ -48,7 +48,7 @@ struct BookDetailsPage: View {
                                 .containerValue(\.viewWidth, viewWidth)
                                 .onTapGesture {
                                     dismiss()
-                                    searchAction(tag)
+                                    searchAction("tag=\(tag)")
                                 }
                         }
                     }
@@ -118,7 +118,7 @@ struct BookDetailsPage: View {
             if let series = book.series, let number = book.seriesNumber {
                 TitledButton(header: "Series", buttonText: series, bookNumber: number) {
                     dismiss()
-                    searchAction(series)
+                    searchAction("series=\(series)")
                 }
             }
             

--- a/MieLibrary/Views/Library/LibraryPage.swift
+++ b/MieLibrary/Views/Library/LibraryPage.swift
@@ -15,7 +15,7 @@ struct LibraryPage: View {
     @State private var searchText: String = ""
     
     private var filteredBooks: [Book] {
-        return searchText.isEmpty ? books : books.filter({ $0.search(with: searchText) })
+        return searchText.isEmpty ? books : books.search(for: searchText)
     }
     
     private let columns: [GridItem] = Array(repeating: GridItem(.flexible(), spacing: 10, alignment: .bottom), count: 5)
@@ -60,7 +60,7 @@ struct LibraryPage: View {
                                 seriesNumber: 1,
                                 isbn: "1234567890",
                                 bookCover: "Fellowship",
-                                tags: ["frodo", "tolkein", "middle-earth", "test", "tag", "book", "apple books"])
+                                tags: ["frodo", "tolkein", "middle-earth"])
 //                            ExampleData.books.randomElement()!
                         )
                     } label: {


### PR DESCRIPTION
I improved the search functionality of the app, where a user can specify what they want to search. These improvements enable a user to type something like <keyword>=<search phrase>, the supported keywords are:
- tag/tags
- author
- publisher
- series
- genre

I also removed the tags from the general search(with:) method in the Book model. So it now only searches the title, subtitle, author, and series.