### PR TITLE
Add Book: Manual Option

### DIFF
--- a/MieLibrary/ContentView.swift
+++ b/MieLibrary/ContentView.swift
@@ -41,6 +41,7 @@ struct ContentView: View {
                 LibraryPage(sorting: $appSettings.sortMethod, order: $appSettings.sortOrder, addBook: { book in
                     modelContext.insert(book)
                 })
+                .modelContext(modelContext)
             }
             
             Tab("Settings", systemImage: "gear") {

--- a/MieLibrary/MieLibraryApp.swift
+++ b/MieLibrary/MieLibraryApp.swift
@@ -26,6 +26,12 @@ struct MieLibraryApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .onAppear {
+                    if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                       let window = windowScene.windows.first {
+                        window.backgroundColor = .accented
+                    }
+                }
         }
         .modelContainer(sharedModelContainer)
     }

--- a/MieLibrary/Models/Book.swift
+++ b/MieLibrary/Models/Book.swift
@@ -114,7 +114,11 @@ final class Book: Identifiable {
             return true
         }
         
-        if author.lowercased().contains(text.lowercased()) {
+        if authorFirstName?.lowercased().contains(text.lowercased()) ?? false {
+            return true
+        }
+        
+        if authorLastName.lowercased().contains(text.lowercased()) {
             return true
         }
         
@@ -139,7 +143,15 @@ extension Array where Element == Book {
             }
             
             if searchText == "author" {
-                return self.filter({ $0.author.lowercased().contains(searchPhrase) })
+                return self.filter({
+                    if $0.authorLastName.lowercased().contains(searchPhrase) {
+                        return true
+                    }
+                    
+                    guard let firstName = $0.authorFirstName else { return false }
+                    
+                    return firstName.lowercased().contains(searchPhrase)
+                })
             }
             
             if searchText == "publisher" {

--- a/MieLibrary/Models/Book.swift
+++ b/MieLibrary/Models/Book.swift
@@ -35,6 +35,11 @@ final class Book: Identifiable {
         return "\(title): \(subTitle)"
     }
     
+    var authorName: String {
+        guard let firstName = authorFirstName else { return "\(authorLastName)" }
+        return "\(firstName) \(authorLastName)"
+    }
+    
     var publishedDateString: String? {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "MM/dd/yyyy"

--- a/MieLibrary/Models/Book.swift
+++ b/MieLibrary/Models/Book.swift
@@ -16,7 +16,8 @@ final class Book: Identifiable {
     }
     var title: String
     var subTitle: String?
-    var author: String
+    var authorFirstName: String?
+    var authorLastName: String
     var publisher: String?
     var publishedDate: Date?
     var numberOfPages: Int?
@@ -55,7 +56,8 @@ final class Book: Identifiable {
     init(
         title: String,
         subTitle: String? = nil,
-        author: String,
+        authorFirstName: String? = nil,
+        authorLastName: String,
         publisher: String? = nil,
         publishedDate: Date? = nil,
         numberOfPages: Int? = nil,
@@ -69,19 +71,38 @@ final class Book: Identifiable {
         isFavorite: Bool = false
     ) {
         self.title = title
-        self.subTitle = subTitle
-        self.author = author
-        self.publisher = publisher
-        self.publishedDate = publishedDate
-        self.numberOfPages = numberOfPages
+        self.authorLastName = authorLastName
         self.genre = genre.rawValue
-        self.series = series
-        self.seriesNumber = seriesNumber
-        self.isbn = isbn
-        self.bookCover = bookCover
         self.tags = tags
         self.dateAdded = dateAdded
         self.isFavorite = isFavorite
+        self.numberOfPages = numberOfPages
+        self.seriesNumber = seriesNumber
+        
+        if let authorFirstName {
+            self.authorFirstName = authorFirstName.isEmpty ? nil : authorFirstName
+        }
+        
+        if let subTitle {
+            self.subTitle = subTitle.isEmpty ? nil : subTitle
+        }
+        
+        if let publisher {
+            self.publisher = publisher.isEmpty ? nil : publisher
+        }
+        
+        if let publishedDate {
+            self.publishedDate = publishedDate
+        }
+        
+        if let series {
+            self.series = series.isEmpty ? nil : series
+        }
+        
+        if let isbn {
+            self.isbn = isbn.isEmpty ? nil : isbn
+        }
+        self.bookCover = bookCover
     }
     
     public func search(with text: String) -> Bool {

--- a/MieLibrary/Models/SortingCategory.swift
+++ b/MieLibrary/Models/SortingCategory.swift
@@ -26,7 +26,8 @@ enum SortingCategory: String, Codable, CaseIterable, Identifiable {
             ]
         case .author: // TODO: Update for when author name is split
             return [
-                SortDescriptor(\Book.author, order: order),
+                SortDescriptor(\Book.authorLastName, order: order),
+                SortDescriptor(\Book.authorFirstName, order: order),
                 SortDescriptor(\Book.title, order: .forward),
                 SortDescriptor(\Book.subTitle, order: .forward)
             ]

--- a/MieLibrary/Preview Content/SampleData.swift
+++ b/MieLibrary/Preview Content/SampleData.swift
@@ -25,21 +25,21 @@ let sampleData: ModelContainer = {
 struct ExampleData {
     static let books: [Book] = {
         return [
-            Book(title: "Lord of the Rings", subTitle: "The Fellowship of the Rings", author: "J.R.R. Tolkien", genre: .fantasy(.high), series: "Lord of the Rings", seriesNumber: 1, bookCover: "Fellowship", tags: ["adventure", "frodo"]),
-            Book(title: "Lord of the Rings", subTitle: "The Two Towers", author: "J.R.R. Tolkien", genre: .fantasy(.high), series: "Lord of the Rings", seriesNumber: 2, bookCover: "Towers", tags: ["adventure", "frodo"]),
-            Book(title: "Lord of the Rings", subTitle: "The Return of the King", author: "J.R.R. Tolkien", genre: .fantasy(.high), series: "Lord of the Rings", seriesNumber: 3, bookCover: "King", tags: ["adventure", "frodo"]),
-            Book(title: "The Hobbit", author: "J.R.R. Tolkien", genre: .fantasy(.high), bookCover: "Hobbit", tags: ["adventure", "bilbo"]),
-            Book(title: "The Historian", author: "Elizabeth Kostava", genre: .mystery(.psychologicalThriller), bookCover: "Historian", tags: ["dracula", "vampires", "history", "europe"]),
-            Book(title: "Dracula", author: "Bram Stoker", genre: .horror, bookCover: "Dracula", tags: ["dracula", "vampires", "history", "europe", "classic", "monsters"]),
-            Book(title: "Frankenstein", author: "Mary Shelley", genre: .horror, bookCover: "Frankenstein", tags: ["frankenstein", "classic", "monsters"]),
-            Book(title: "World War Z", author: "Max Brooks", genre: .literaryFiction(.postApocalytic), bookCover: "World War", tags: ["zombies", "monsters"]),
-            Book(title: "1984", author: "George Orwell", genre: .literaryFiction(.dystopian), bookCover: "1984", tags: ["classic", "politics", "socialism"]),
-            Book(title: "Animal Farm", author: "George Orwell", genre: .literaryFiction(.dystopian), bookCover: "Farm", tags: ["classic", "politics", "warning"]),
-            Book(title: "Brave New World", author: "Aldous Huxley", genre: .literaryFiction(.dystopian), bookCover: "Brave", tags: ["classic", "politics", "warning"]),
-            Book(title: "The Girl with all the Gifts", author: "M.R. Carey", genre: .literaryFiction(.postApocalytic), bookCover: "Gifts", tags: ["zombies"]),
-            Book(title: "The Boy on the Bridge", author: "M.R. Carey", genre: .literaryFiction(.postApocalytic), bookCover: "Bridge", tags: ["zombies"]),
-            Book(title: "The Passage", author: "Justin Cronin", genre: .literaryFiction(.postApocalytic), bookCover: "Passage", tags: ["zombies", "vampires"]),
-            Book(title: "The Zombie Survival Guide", subTitle: "Complete Protection From The Living Dead", author: "Max Brooks", genre: .literaryFiction(.urbanFantasy), tags: ["zombies", "survival"])
+            Book(title: "Lord of the Rings", subTitle: "The Fellowship of the Rings", authorLastName: "Tolkien", genre: .fantasy(.high), series: "Lord of the Rings", seriesNumber: 1, bookCover: "Fellowship", tags: ["adventure", "frodo"]),
+            Book(title: "Lord of the Rings", subTitle: "The Two Towers", authorLastName: "Tolkien", genre: .fantasy(.high), series: "Lord of the Rings", seriesNumber: 2, bookCover: "Towers", tags: ["adventure", "frodo"]),
+            Book(title: "Lord of the Rings", subTitle: "The Return of the King", authorLastName: "Tolkien", genre: .fantasy(.high), series: "Lord of the Rings", seriesNumber: 3, bookCover: "King", tags: ["adventure", "frodo"]),
+            Book(title: "The Hobbit", authorLastName: "Tolkien", genre: .fantasy(.high), bookCover: "Hobbit", tags: ["adventure", "bilbo"]),
+            Book(title: "The Historian", authorLastName: "Kostava", genre: .mystery(.psychologicalThriller), bookCover: "Historian", tags: ["dracula", "vampires", "history", "europe"]),
+            Book(title: "Dracula", authorLastName: "Stoker", genre: .horror, bookCover: "Dracula", tags: ["dracula", "vampires", "history", "europe", "classic", "monsters"]),
+            Book(title: "Frankenstein", authorLastName: "Shelley", genre: .horror, bookCover: "Frankenstein", tags: ["frankenstein", "classic", "monsters"]),
+            Book(title: "World War Z", authorLastName: "Brooks", genre: .literaryFiction(.postApocalytic), bookCover: "World War", tags: ["zombies", "monsters"]),
+            Book(title: "1984", authorLastName: "Orwell", genre: .literaryFiction(.dystopian), bookCover: "1984", tags: ["classic", "politics", "socialism"]),
+            Book(title: "Animal Farm", authorLastName: "Orwell", genre: .literaryFiction(.dystopian), bookCover: "Farm", tags: ["classic", "politics", "warning"]),
+            Book(title: "Brave New World", authorLastName: "Huxley", genre: .literaryFiction(.dystopian), bookCover: "Brave", tags: ["classic", "politics", "warning"]),
+            Book(title: "The Girl with all the Gifts", authorLastName: "Carey", genre: .literaryFiction(.postApocalytic), bookCover: "Gifts", tags: ["zombies"]),
+            Book(title: "The Boy on the Bridge", authorLastName: "Carey", genre: .literaryFiction(.postApocalytic), bookCover: "Bridge", tags: ["zombies"]),
+            Book(title: "The Passage", authorLastName: "Cronin", genre: .literaryFiction(.postApocalytic), bookCover: "Passage", tags: ["zombies", "vampires"]),
+            Book(title: "The Zombie Survival Guide", subTitle: "Complete Protection From The Living Dead", authorLastName: "Brooks", genre: .literaryFiction(.urbanFantasy), tags: ["zombies", "survival"])
         ]
     }()
 }

--- a/MieLibrary/ViewModels/BookInputViewModel.swift
+++ b/MieLibrary/ViewModels/BookInputViewModel.swift
@@ -16,7 +16,7 @@ class BookInputViewModel {
     var authorFirstName: String = ""
     var authorLastName: String = ""
     var publisher: String = ""
-    var publishedDate: Date? = nil
+    var publishedDate: Date
     var numberOfPages: String = ""
     var genre: GenreType? = nil
     var series: String = ""
@@ -24,18 +24,20 @@ class BookInputViewModel {
     var isbn: String = ""
     var inputTag: String = ""
     var showMissingFields: Bool = false
+    private let publishedDateDefaultValue: Date
     
     var tags: [String] = []
     
     init(book: Book? = nil) {
         self.book = book
+        publishedDateDefaultValue = Date()
         
         _title = book?.title ?? ""
         _subtitle = book?.subTitle ?? ""
         _authorFirstName = book?.authorFirstName ?? ""
         _authorLastName = book?.authorLastName ?? ""
         _publisher = book?.publisher ?? ""
-        _publishedDate = book?.publishedDate ?? .init()
+        _publishedDate = book?.publishedDate ?? publishedDateDefaultValue
         _numberOfPages = book?.numberOfPages == nil ? "" : String(book!.numberOfPages!)
         if let genre = book?.genre {
             _genre = GenreType(rawValue: genre)
@@ -48,13 +50,15 @@ class BookInputViewModel {
     
     func constructBook() -> Book? {
         if let genre, !title.isEmpty, !authorLastName.isEmpty {
+            showMissingFields = false
+            
             return .init(
                 title: title,
                 subTitle: subtitle,
                 authorFirstName: authorFirstName,
                 authorLastName: authorLastName,
                 publisher: publisher,
-                publishedDate: publishedDate,
+                publishedDate: publishedDate == publishedDateDefaultValue ? nil : publishedDate,
                 numberOfPages: Int(numberOfPages),
                 genre: genre,
                 series: series,
@@ -83,9 +87,11 @@ class BookInputViewModel {
             book.seriesNumber = Int(seriesNumber)
             book.isbn = isbn.isEmpty ? nil : isbn
             book.tags = tags
+            
+            showMissingFields = false
+        } else {
+            showMissingFields = true
         }
-        
-        showMissingFields = true
     }
     
     func removeTag(_ tag: String) {

--- a/MieLibrary/ViewModels/BookInputViewModel.swift
+++ b/MieLibrary/ViewModels/BookInputViewModel.swift
@@ -78,7 +78,7 @@ class BookInputViewModel {
             book.publisher = publisher.isEmpty ? nil : publisher
             book.publishedDate = publishedDate
             book.numberOfPages = Int(numberOfPages)
-            book.genre = genre.rawValue ?? book.genre
+            book.genre = genre.rawValue
             book.series = series.isEmpty ? nil : series
             book.seriesNumber = Int(seriesNumber)
             book.isbn = isbn.isEmpty ? nil : isbn

--- a/MieLibrary/ViewModels/BookInputViewModel.swift
+++ b/MieLibrary/ViewModels/BookInputViewModel.swift
@@ -80,6 +80,15 @@ class BookInputViewModel {
         }
     }
     
+    func constructBook() -> Book? {
+        if let genre, !title.isEmpty, !author.isEmpty {
+            let book = Book(title: title, author: author, genre: genre, tags: tags)
+            return book
+        } else {
+            return nil
+        }
+    }
+    
     func removeTag(_ tag: String) {
         tags.removeAll(where: { $0 == tag })
     }

--- a/MieLibrary/ViewModels/BookInputViewModel.swift
+++ b/MieLibrary/ViewModels/BookInputViewModel.swift
@@ -16,21 +16,16 @@ class BookInputViewModel {
     var authorFirstName: String = ""
     var authorLastName: String = ""
     var publisher: String = ""
-    var publishedDate: Date?
-    var numberOfPagesRaw: String = ""
+    var publishedDate: Date? = nil
+    var numberOfPages: String = ""
     var genre: GenreType? = nil
     var series: String = ""
-    var seriesNumberRaw: String = ""
+    var seriesNumber: String = ""
     var isbn: String = ""
     var inputTag: String = ""
+    var showMissingFields: Bool = false
     
     var tags: [String] = []
-    private var numberOfPages: Int? {
-        Int(numberOfPagesRaw)
-    }
-    private var seriesNumber: Int? {
-        Int(seriesNumberRaw)
-    }
     
     init(book: Book? = nil) {
         self.book = book
@@ -41,45 +36,56 @@ class BookInputViewModel {
         _authorLastName = book?.authorLastName ?? ""
         _publisher = book?.publisher ?? ""
         _publishedDate = book?.publishedDate ?? .init()
-        _numberOfPagesRaw = book?.numberOfPages == nil ? "" : String(book!.numberOfPages!)
-        _genre = GenreType(rawValue: book?.genre ?? "Adventure")
+        _numberOfPages = book?.numberOfPages == nil ? "" : String(book!.numberOfPages!)
+        if let genre = book?.genre {
+            _genre = GenreType(rawValue: genre)
+        }
         _series = book?.series ?? ""
-        _seriesNumberRaw = book?.seriesNumber == nil ? "" : String(book!.seriesNumber!)
+        _seriesNumber = book?.seriesNumber == nil ? "" : String(book!.seriesNumber!)
         _isbn = book?.isbn ?? ""
         _tags = book?.tags ?? []
     }
     
-    func addedBook() -> Book {
-        return .init(
-            title: title,
-            subTitle: subtitle.isEmpty ? nil : subtitle,
-            author: author,
-            publisher: publisher.isEmpty ? nil : publisher,
-            publishedDate: publishedDate,
-            numberOfPages: numberOfPages == 0 ? nil : numberOfPages,
-            genre: genre!,
-            series: series.isEmpty ? nil : series,
-            seriesNumber: seriesNumber == 0 ? nil : seriesNumber,
-            isbn: isbn.isEmpty ? nil : isbn,
-            bookCover: nil, // TODO: Implement logic for saving the bookCover in the cache and create a URL string
-            tags: tags
-        )
+    func constructBook() -> Book? {
+        if let genre, !title.isEmpty, !authorLastName.isEmpty {
+            return .init(
+                title: title,
+                subTitle: subtitle,
+                authorFirstName: authorFirstName,
+                authorLastName: authorLastName,
+                publisher: publisher,
+                publishedDate: publishedDate,
+                numberOfPages: Int(numberOfPages),
+                genre: genre,
+                series: series,
+                seriesNumber: Int(seriesNumber),
+                isbn: isbn,
+                bookCover: nil, // TODO: Implement logic for saving the bookCover in the cache and create a URL string
+                tags: tags
+            )
+        }
+        
+        showMissingFields = true
+        return nil
     }
     
     func updateBook() {
-        if let book {
+        if let book, let genre, !title.isEmpty, !authorLastName.isEmpty {
             book.title = title
             book.subTitle = subtitle.isEmpty ? nil : subtitle
-            book.author = author
+            book.authorFirstName = authorFirstName.isEmpty ? nil : authorFirstName
+            book.authorLastName = authorLastName
             book.publisher = publisher.isEmpty ? nil : publisher
             book.publishedDate = publishedDate
-            book.numberOfPages = numberOfPages
-            book.genre = genre?.rawValue ?? book.genre
+            book.numberOfPages = Int(numberOfPages)
+            book.genre = genre.rawValue ?? book.genre
             book.series = series.isEmpty ? nil : series
-            book.seriesNumber = seriesNumber
+            book.seriesNumber = Int(seriesNumber)
             book.isbn = isbn.isEmpty ? nil : isbn
             book.tags = tags
         }
+        
+        showMissingFields = true
     }
     
     func removeTag(_ tag: String) {

--- a/MieLibrary/ViewModels/BookInputViewModel.swift
+++ b/MieLibrary/ViewModels/BookInputViewModel.swift
@@ -13,9 +13,10 @@ class BookInputViewModel {
     
     var title: String = ""
     var subtitle: String = ""
-    var author: String = ""
+    var authorFirstName: String = ""
+    var authorLastName: String = ""
     var publisher: String = ""
-    var publishedDate: Date = .init()
+    var publishedDate: Date?
     var numberOfPagesRaw: String = ""
     var genre: GenreType? = nil
     var series: String = ""
@@ -36,7 +37,8 @@ class BookInputViewModel {
         
         _title = book?.title ?? ""
         _subtitle = book?.subTitle ?? ""
-        _author = book?.author ?? ""
+        _authorFirstName = book?.authorFirstName ?? ""
+        _authorLastName = book?.authorLastName ?? ""
         _publisher = book?.publisher ?? ""
         _publishedDate = book?.publishedDate ?? .init()
         _numberOfPagesRaw = book?.numberOfPages == nil ? "" : String(book!.numberOfPages!)
@@ -77,15 +79,6 @@ class BookInputViewModel {
             book.seriesNumber = seriesNumber
             book.isbn = isbn.isEmpty ? nil : isbn
             book.tags = tags
-        }
-    }
-    
-    func constructBook() -> Book? {
-        if let genre, !title.isEmpty, !author.isEmpty {
-            let book = Book(title: title, author: author, genre: genre, tags: tags)
-            return book
-        } else {
-            return nil
         }
     }
     

--- a/MieLibrary/ViewModifiers/TextModifier.swift
+++ b/MieLibrary/ViewModifiers/TextModifier.swift
@@ -30,6 +30,7 @@ struct TextModifier: ViewModifier {
         case .info:             return 20
         case .sectionHeader:    return 24
         case .button:           return 20
+        case .errorMessage:     return 14
         }
     }
     
@@ -65,15 +66,17 @@ extension TextModifier {
         case info
         case sectionHeader
         case button
+        case errorMessage
         
         func font(size: CGFloat) -> Font {
             switch self {
-            case .header:           return .system(size: size, weight: .black, design: .default)
-            case .subheader:        return .system(size: size, weight: .heavy, design: .default)
-            case .body:             return .system(size: size, weight: .regular, design: .default)
-            case .info:             return .system(size: size, weight: .light, design: .default)
-            case .sectionHeader:    return .system(size: size, weight: .heavy, design: .default)
-            case .button:           return .system(size: size, weight: .semibold, design: .default)
+            case .header:           return .system(size: size, weight: .black)
+            case .subheader:        return .system(size: size, weight: .heavy)
+            case .body:             return .system(size: size, weight: .regular)
+            case .info:             return .system(size: size, weight: .light)
+            case .sectionHeader:    return .system(size: size, weight: .heavy)
+            case .button:           return .system(size: size, weight: .semibold)
+            case .errorMessage:     return .system(size: size, weight: .light)
             }
         }
     }

--- a/MieLibrary/Views/AccessoryViews/TitledTextField.swift
+++ b/MieLibrary/Views/AccessoryViews/TitledTextField.swift
@@ -11,12 +11,14 @@ struct TitledTextField: View {
     
     var title: String
     var type: TitleType
+    var titleColor: Color
     @Binding var text: String
     var onDone: (() -> Void)?
     
-    init(_ title: String, text: Binding<String>, titleType: TitleType = .vertical, onDone: (() -> Void)? = nil) {
+    init(_ title: String, text: Binding<String>, titleType: TitleType = .vertical, titleColor: Color = .text, onDone: (() -> Void)? = nil) {
         self.title = title
         self.type = titleType
+        self.titleColor = titleColor
         self._text = text
         self.onDone = onDone
     }
@@ -32,7 +34,7 @@ struct TitledTextField: View {
     private func VerticalLook() -> some View {
         VStack(alignment: .leading) {
             Text(title)
-                .themeStyle(.subheader)
+                .themeStyle(.subheader, fontColor: titleColor)
             
             TextField("", text: $text)
                 .themeStyle(.body)
@@ -48,7 +50,7 @@ struct TitledTextField: View {
     private func HorizontalLook() -> some View {
         HStack(alignment: .center) {
             Text(title)
-                .themeStyle(.subheader)
+                .themeStyle(.subheader, fontColor: titleColor)
             
             Spacer()
             

--- a/MieLibrary/Views/BookDetails/BookDetailsPage.swift
+++ b/MieLibrary/Views/BookDetails/BookDetailsPage.swift
@@ -115,7 +115,7 @@ struct BookDetailsPage: View {
         VStack(spacing: 16) {
             TitledText(header: "Title", text: book.fullTitle)
             
-            TitledText(header: "Author", text: book.author)
+            TitledText(header: "Author", text: book.authorName)
         }
     }
     
@@ -187,7 +187,7 @@ struct BookDetailsPage: View {
     let book = Book(
         title: "Lord of the Rings",
         subTitle: "Fellowship of the Rings",
-        author: "J.R.R Tolkein",
+        authorLastName: "Tolkein",
         publisher: "Houghton Miffin",
         publishedDate: .init(),
         numberOfPages: 423,

--- a/MieLibrary/Views/BookInputPage/BookInputPage.swift
+++ b/MieLibrary/Views/BookInputPage/BookInputPage.swift
@@ -37,7 +37,8 @@ struct BookInputPage: View {
                         if vm.showMissingFields {
                             Text("Please fill in all the fields that are highlighted before continuing.")
                                 .themeStyle(.errorMessage)
-                                .padding()
+                                .padding(.horizontal)
+                                .padding(.vertical, 5)
                                 .background(RoundedRectangle(cornerRadius: 6).fill(Color.highlight))
                                 .id("error")
                         }
@@ -99,7 +100,7 @@ struct BookInputPage: View {
                         
                         TitledTextField("Publisher", text: $vm.publisher)
                         
-                        DatePicker("Published Date", selection: Binding<Date>(get: {vm.publishedDate ?? Date()}, set: {vm.publishedDate = $0}), displayedComponents: .date)
+                        DatePicker("Published Date", selection: $vm.publishedDate, displayedComponents: .date)
                             .themeStyle(.subheader)
                             .padding(.vertical, 8)
                         
@@ -117,7 +118,7 @@ struct BookInputPage: View {
                             if !vm.showMissingFields {
                                 dismiss()
                             } else {
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1){
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.01){
                                     withAnimation(.easeInOut) {
                                         proxy.scrollTo("error", anchor: .top)
                                     }

--- a/MieLibrary/Views/BookInputPage/BookInputPage.swift
+++ b/MieLibrary/Views/BookInputPage/BookInputPage.swift
@@ -33,17 +33,17 @@ struct BookInputPage: View {
             
             ScrollView {
                 VStack(spacing: 16) {
-                    TitledTextField("Title", text: $vm.title)
+                    TitledTextField("Title", text: $vm.title, titleColor: (vm.showMissingFields && vm.title.isEmpty) ? .highlight : .text)
                     
                     TitledTextField("Subtitle", text: $vm.subtitle)
                     
                     TitledTextField("Author First Name", text: $vm.authorFirstName)
                     
-                    TitledTextField("Author Last Name", text: $vm.authorLastName)
+                    TitledTextField("Author Last Name", text: $vm.authorLastName, titleColor: (vm.showMissingFields && vm.authorLastName.isEmpty) ? .highlight : .text)
                     
                     HStack(alignment: .center) {
                         Text("Genre")
-                            .themeStyle(.subheader)
+                            .themeStyle(.subheader, fontColor: (vm.showMissingFields && vm.genre == nil) ? .highlight : .text)
                         
                         Spacer()
                         
@@ -63,10 +63,10 @@ struct BookInputPage: View {
                     
                     TitledTextField("Series", text: $vm.series)
                     
-                    TitledTextField("# in Series", text: $vm.seriesNumberRaw, titleType: .horizontal)
+                    TitledTextField("# in Series", text: $vm.seriesNumber, titleType: .horizontal)
                         .keyboardType(.numberPad)
                     
-                    TitledTextField("# of Pages", text: $vm.numberOfPagesRaw, titleType: .horizontal)
+                    TitledTextField("# of Pages", text: $vm.numberOfPages, titleType: .horizontal)
                         .keyboardType(.numberPad)
                     
                     TagsView {
@@ -100,10 +100,14 @@ struct BookInputPage: View {
                         if vm.book != nil {
                             vm.updateBook()
                         }
+                        
                         if let addBook, let book = vm.constructBook() {
                             addBook(book)
                         }
-                        dismiss()
+                        
+                        if !vm.showMissingFields {
+                            dismiss()
+                        }
                     } label: {
                         Text(vm.book != nil ? "Save" : "Add")
                             .themeStyle(.button)

--- a/MieLibrary/Views/BookInputPage/BookInputPage.swift
+++ b/MieLibrary/Views/BookInputPage/BookInputPage.swift
@@ -37,7 +37,9 @@ struct BookInputPage: View {
                     
                     TitledTextField("Subtitle", text: $vm.subtitle)
                     
-                    TitledTextField("Author", text: $vm.author)
+                    TitledTextField("Author First Name", text: $vm.authorFirstName)
+                    
+                    TitledTextField("Author Last Name", text: $vm.authorLastName)
                     
                     HStack(alignment: .center) {
                         Text("Genre")

--- a/MieLibrary/Views/BookInputPage/BookInputPage.swift
+++ b/MieLibrary/Views/BookInputPage/BookInputPage.swift
@@ -11,9 +11,11 @@ struct BookInputPage: View {
     @Environment(\.dismiss) var dismiss
     
     @State var vm: BookInputViewModel
+    var addBook: ((Book) -> Void)?
     
-    init(book: Book? = nil) {
+    init(book: Book? = nil, addBook: ((Book) -> Void)? = nil) {
         _vm = .init(initialValue: .init(book: book))
+        self.addBook = addBook
     }
     
     var body: some View {
@@ -96,9 +98,12 @@ struct BookInputPage: View {
                         if vm.book != nil {
                             vm.updateBook()
                         }
+                        if let addBook, let book = vm.constructBook() {
+                            addBook(book)
+                        }
                         dismiss()
                     } label: {
-                        Text("Save")
+                        Text(vm.book != nil ? "Save" : "Add")
                             .themeStyle(.button)
                             .padding(.vertical, 8)
                             .padding(.horizontal, 48)

--- a/MieLibrary/Views/BookInputPage/BookInputPage.swift
+++ b/MieLibrary/Views/BookInputPage/BookInputPage.swift
@@ -88,7 +88,7 @@ struct BookInputPage: View {
                     
                     TitledTextField("Publisher", text: $vm.publisher)
                     
-                    DatePicker("Published Date", selection: $vm.publishedDate, displayedComponents: .date)
+                    DatePicker("Published Date", selection: Binding<Date>(get: {vm.publishedDate ?? Date()}, set: {vm.publishedDate = $0}), displayedComponents: .date)
                         .themeStyle(.subheader)
                         .padding(.vertical, 8)
                     
@@ -128,7 +128,8 @@ struct BookInputPage: View {
                     Book(
                         title: "Lord of the Rings",
                         subTitle: "Fellowship of the Rings",
-                        author: "J.R.R Tolkein",
+                        authorFirstName: "J.R.R.",
+                        authorLastName: "Tolkein",
                         publisher: "Houghton Miffin",
                         publishedDate: .init(),
                         numberOfPages: 423,

--- a/MieLibrary/Views/Library/LibraryPage.swift
+++ b/MieLibrary/Views/Library/LibraryPage.swift
@@ -9,11 +9,13 @@ import SwiftUI
 import SwiftData
 
 struct LibraryPage: View {
+    @Environment(\.modelContext) private var modelContext
     
     @Query private var books: [Book]
     var addBook: ((Book) -> Void)
     
     @State private var showSortPage: Bool = false
+    @State private var addBookManually: Bool = false
     @State private var searchText: String = ""
     @Binding var sorting: SortingCategory
     @Binding var sortDirection: SortOrder
@@ -67,28 +69,22 @@ struct LibraryPage: View {
                 }
                 
                 ToolbarItem {
-                    Button {
-                        addBook(
-                            Book(
-                                title: "Lord of the Rings",
-                                subTitle: "Fellowship of the Rings",
-                                author: "J.R.R Tolkein",
-                                publisher: "Houghton Miffin",
-                                publishedDate: .init(),
-                                numberOfPages: 423,
-                                genre: .fantasy(.high),
-                                series: "Lord of the Rings",
-                                seriesNumber: 1,
-                                isbn: "1234567890",
-                                bookCover: "Fellowship",
-                                tags: ["frodo", "tolkein", "middle-earth"])
-                        )
-                    } label: {
-                        Image(systemName: "plus")
-                            .foregroundStyle(Color.text)
-                            .accessibilityLabel("Add Item")
+                    Menu("Add Book", systemImage: "plus") {
+                        Button {
+                            addBookManually.toggle()
+                        } label: {
+                            Label("Add Manually", systemImage: "text.book.closed.fill")
+                        }
+                        
+                        Button {
+                            print("Scan Barcode")
+                        } label: {
+                            Label("Scan Barcode", systemImage: "barcode.viewfinder")
+                        }
                     }
+                    .foregroundStyle(Color.text)
                 }
+                
             }
             .navigationDestination(for: Book.self) { book in
                 BookDetailsPage(book: book) { searchTerm in
@@ -97,9 +93,13 @@ struct LibraryPage: View {
             }
             .sheet(isPresented: $showSortPage) {
                 SortPage(selection: $sorting, order: $sortDirection)
-//                    .presentationDetents([.fraction(0.7)])
                     .presentationDetents([.fraction(0.7)])
                     .presentationDragIndicator(.visible)
+            }
+            .sheet(isPresented: $addBookManually) {
+                BookInputPage { book in
+                    modelContext.insert(book)
+                }
             }
         }
         .tint(.text)


### PR DESCRIPTION
Updated the BookInputPage to support adding books manually. If a user taps the '+' button, it will present a context menu with two options: "Add Manually" and "Scan Barcode". If the user taps the "Add Manually" option, it will present the BookInputPage. Then if the user inputs the data correctly, it will add the book to the Library. If the user doesn't input the Title, Author Last Name, or Genre the page will display an error at the top of the page, and highlight the fields that are required and missing.